### PR TITLE
Fix Soliah theme so it doesn’t print error messages for missing commands

### DIFF
--- a/themes/Soliah.zsh-theme
+++ b/themes/Soliah.zsh-theme
@@ -5,10 +5,10 @@ ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[white]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%})"
 
 # Text to display if the branch is dirty
-ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[red]%}*%{$reset_color%}" 
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[red]%}*%{$reset_color%}"
 
 # Text to display if the branch is clean
-ZSH_THEME_GIT_PROMPT_CLEAN="" 
+ZSH_THEME_GIT_PROMPT_CLEAN=""
 
 # Colors vary depending on time lapsed.
 ZSH_THEME_GIT_TIME_SINCE_COMMIT_SHORT="%{$fg[green]%}"
@@ -21,6 +21,7 @@ ZSH_THEME_GIT_TIME_SINCE_COMMIT_NEUTRAL="%{$fg[cyan]%}"
 # return anything in this case. So wrap it in another function and check
 # for an empty string.
 function check_git_prompt_info() {
+    which git &> /dev/null || return
     if git rev-parse --git-dir > /dev/null 2>&1; then
         if [[ -z $(git_prompt_info) ]]; then
             echo "%{$fg[magenta]%}detached-head%{$reset_color%})"
@@ -32,11 +33,11 @@ function check_git_prompt_info() {
 
 # Determine if we are using a gemset.
 function rvm_gemset() {
+    which rvm &> /dev/null || return
     GEMSET=`rvm gemset list | grep '=>' | cut -b4-`
     if [[ -n $GEMSET ]]; then
         echo "%{$fg[yellow]%}$GEMSET%{$reset_color%}|"
-    fi 
-
+    fi
 }
 
 # Determine the time since last commit. If branch is clean,
@@ -53,12 +54,12 @@ function git_time_since_commit() {
             # Totals
             MINUTES=$((seconds_since_last_commit / 60))
             HOURS=$((seconds_since_last_commit/3600))
-           
+
             # Sub-hours and sub-minutes
             DAYS=$((seconds_since_last_commit / 86400))
             SUB_HOURS=$((HOURS % 24))
             SUB_MINUTES=$((MINUTES % 60))
-            
+
             if [[ -n $(git status -s 2> /dev/null) ]]; then
                 if [ "$MINUTES" -gt 30 ]; then
                     COLOR="$ZSH_THEME_GIT_TIME_SINCE_COMMIT_LONG"


### PR DESCRIPTION
Other themes may also have this issue; if a helper command is missing
(in my case it was rvm), an error message is printed on the screen
about it not being found.
